### PR TITLE
Add priors for LumaI16x16Mode and ChromaI8x8Mode and tweak scan/emitt…

### DIFF
--- a/codec/decoder/core/inc/compression_stream.h
+++ b/codec/decoder/core/inc/compression_stream.h
@@ -225,15 +225,15 @@ public:
     };
 
     template<int nBits>
-    std::pair<uint32_t, H264Error> scanBitsZeroToPow2Inclusive(typename Sirikata::Array1d<DynProb, (1<< nBits) >::Slice priors) {
+      std::pair<uint32_t, H264Error> scanBitsZeroToPow2Inclusive(typename Sirikata::Array1d<DynProb, (1<< nBits) >::Slice priors, uint32_t preferred = 0) {
         bool zeroBit = scanBit(&priors.at(0));
-        std::pair<uint32_t, H264Error> retval (0,0);
+        std::pair<uint32_t, H264Error> retval (preferred, 0);
         if (!zeroBit) {
             return retval;
         }
         SliceRange<1, (1<<nBits)> sr;
         retval = scanBits(Branch<nBits>(priors.slice(sr)));
-        retval.first += 1;
+        retval.first += retval.first >= preferred ? 1 : 0;
         return retval;
     }
 };
@@ -312,12 +312,12 @@ public:
         enum {START=start, END=end};
     };
     template <int nBits>
-    void emitBitsZeroToPow2Inclusive(uint32_t data, typename Sirikata::Array1d<DynProb, (1<< nBits)>::Slice priors) {
-        bool zeroBit = (data != 0);
+      void emitBitsZeroToPow2Inclusive(uint32_t data, typename Sirikata::Array1d<DynProb, (1<< nBits)>::Slice priors, uint32_t preferred = 0) {
+        bool zeroBit = (data != preferred);
         emitBit(zeroBit, &priors.at(0));
-        if (data) {
+        if (data != preferred) {
             SliceRange<1, (1<<nBits)>sr;
-            emitBits(data - 1, Branch<nBits>(priors.slice(sr)));
+            emitBits(data > preferred ? (data - 1) : data, Branch<nBits>(priors.slice(sr)));
         }
     }
 };

--- a/codec/decoder/core/inc/macroblock_model.h
+++ b/codec/decoder/core/inc/macroblock_model.h
@@ -99,6 +99,8 @@ class MacroblockModel {
     WelsDec::PWelsDecoderContext pCtx;
     Neighbors n;
     Sirikata::Array3d<DynProb, 32, 2, 15> mbTypePriors; // We could use just 8 bits for I Slices
+    Sirikata::Array2d<DynProb, 8, 8> lumaI16x16ModePriors;
+    Sirikata::Array2d<DynProb, 8, 8> chromaI8x8ModePriors;
      Sirikata::Array3d<DynProb,
         257, // prev frame or neighbor 4x16 + 16x4
         16,//mbType
@@ -123,6 +125,8 @@ public:
                                const FreqImage *, int mbx, int mby);
 
     Branch<4> getMacroblockTypePrior();
+    std::pair<Sirikata::Array1d<DynProb, 8>::Slice, uint32_t> getLumaI16x16ModePrior();
+    std::pair<Sirikata::Array1d<DynProb, 8>::Slice, uint32_t> getChromaI8x8ModePrior();
     Sirikata::Array1d<DynProb, 256>::Slice getLumaNumNonzerosPrior();
     Sirikata::Array1d<DynProb, 128>::Slice getChromaNumNonzerosPrior();
     Branch<8> getLumaNumNonzerosPriorBranch() {


### PR DESCRIPTION
…ing power-of-2 bits

Also, allow scanBitsZeroToPow2Inclusive and emit\* to specify preferred integer to encode at the root. This is because it turns out that LumaI16x16Mode and ChromaI8x8Mode are very likely to match those from N[PAST]. So we want to specify a nonzero integer at the top.

On the first test video:
9 :: 13222 [8x8]
10 :: 6121 [16x16]

Now:
9 :: 2576 [8x8]
10 :: 1460 [16x16]

I've tweaked settings a bit, but seems to not change much

Original encoding:
10 :: 10899.625000   [16x16](doesn't report 8x8.)
